### PR TITLE
Revamp live activity UI and transcript layout

### DIFF
--- a/frontend/src/components/ui/button.tsx
+++ b/frontend/src/components/ui/button.tsx
@@ -9,10 +9,10 @@ type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
 
 const variantStyles: Record<ButtonVariant, string> = {
   default:
-    "bg-blue-500 hover:bg-blue-400 text-white transition-colors duration-200",
+    "bg-gradient-to-r from-sky-500 via-indigo-500 to-purple-500 text-white shadow-[0_12px_30px_rgba(56,189,248,0.35)] transition-all duration-200 hover:brightness-105",
   outline:
-    "border border-white/10 bg-transparent hover:bg-white/5 transition-colors duration-200",
-  ghost: "bg-transparent hover:bg-white/10",
+    "border border-white/15 bg-transparent text-white hover:bg-white/10 transition-colors duration-200",
+  ghost: "bg-transparent text-white hover:bg-white/10",
 };
 
 export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(

--- a/frontend/src/hooks/use-voice-chat.ts
+++ b/frontend/src/hooks/use-voice-chat.ts
@@ -57,7 +57,14 @@ export function useVoiceChat(): HookState {
 
   const pushActivity = useCallback((type: ActivityEvent["type"]) => {
     const timestamp = Date.now();
-    setActivities((prev) => [...prev.slice(-300), { timestamp, type }]);
+    setActivities((prev) => {
+      const trimmed = prev.slice(-299);
+      const last = trimmed[trimmed.length - 1];
+      if (last?.type === type) {
+        return trimmed;
+      }
+      return [...trimmed, { timestamp, type }];
+    });
   }, []);
 
   useEffect(() => {
@@ -156,6 +163,7 @@ export function useVoiceChat(): HookState {
             setIsAISpeaking(false);
             if (!isUserSpeaking) {
               setCurrentSpeaker("silence");
+              pushActivity("silence");
             }
           },
         });
@@ -183,7 +191,7 @@ export function useVoiceChat(): HookState {
       await playbackRef.current?.stop();
       setIsRunning(false);
     }
-  }, [isRunning, isUserSpeaking]);
+  }, [isRunning, isUserSpeaking, pushActivity]);
 
   const stop = useCallback(async () => {
     if (!isRunning) return;
@@ -197,7 +205,8 @@ export function useVoiceChat(): HookState {
     setIsAISpeaking(false);
     setIsUserSpeaking(false);
     setCurrentSpeaker("silence");
-  }, [isRunning]);
+    pushActivity("silence");
+  }, [isRunning, pushActivity]);
 
   return useMemo(
     () => ({


### PR DESCRIPTION
## Summary
- redesign the live activity surface with smoother waveform rendering, refreshed controls, and mockup-aligned styling
- surface the conversation transcript alongside the timeline with auto-scrolling, speaker avatars, and modern typography
- tighten activity tracking so duplicate segments are avoided and silence is recorded when playback ends

## Testing
- npm run lint *(fails: Cannot find package '@eslint/eslintrc' referenced by eslint.config.mjs)*

------
https://chatgpt.com/codex/tasks/task_e_68f6414ad280832d9febb21c865aa6d2