### PR TITLE
Fix frontend auto-scroll bug

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -84,13 +84,6 @@ export default function Page() {
     return "bg-red-500/10 text-red-200 ring-1 ring-red-500/30";
   }, [isConnected, isRunning]);
 
-  // Prevent any unintended page scrolling on mount
-  useEffect(() => {
-    if (typeof window !== "undefined") {
-      // Ensure we're at the top of the page and prevent auto-scrolling
-      window.scrollTo(0, 0);
-    }
-  }, []);
 
   const drawWaveform = useCallback(() => {
     const canvas = canvasRef.current;


### PR DESCRIPTION
Remove `useEffect` with `window.scrollTo(0, 0)` to fix unintended auto-scrolling on page load.

The `useEffect` hook, intended to prevent auto-scrolling, was ironically causing a visible scroll animation on page load when combined with `scroll-behavior: smooth`. Removing it allows the page to load naturally at the top without any forced scrolling.

---
<a href="https://cursor.com/background-agent?bcId=bc-6a9c1f0c-2245-4695-aef5-7ee0b6ec8636"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6a9c1f0c-2245-4695-aef5-7ee0b6ec8636"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

