### PR TITLE
Restyle Agent Command Center UI

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -1,3 +1,33 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+:root {
+  color-scheme: dark;
+}
+
+body {
+  font-family: var(--font-sans, "Inter", "SF Pro Display", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif);
+}
+
+* {
+  scrollbar-width: thin;
+  scrollbar-color: #374151 transparent;
+}
+
+*::-webkit-scrollbar {
+  width: 8px;
+}
+
+*::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+*::-webkit-scrollbar-thumb {
+  background-color: #374151;
+  border-radius: 9999px;
+}
+
+*::-webkit-scrollbar-thumb:hover {
+  background-color: #4b5563;
+}

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,21 +1,21 @@
-import type { Metadata } from 'next'
-import './globals.css'
+import type { Metadata } from "next";
+import "./globals.css";
 
 export const metadata: Metadata = {
-  title: 'WebRTC Voice Assistant',
-  description: 'Realtime voice chatbot using WebRTC',
-}
+  title: "WebRTC Voice Assistant",
+  description: "Realtime voice chatbot using WebRTC",
+};
 
 export default function RootLayout({
   children,
 }: {
-  children: React.ReactNode
+  children: React.ReactNode;
 }) {
   return (
     <html lang="en">
-      <body className="min-h-screen bg-gradient-to-br from-gray-900 to-gray-800 text-white">
+      <body className="min-h-screen bg-black text-white antialiased">
         {children}
       </body>
     </html>
-  )
+  );
 }


### PR DESCRIPTION
## Summary
- restyle the Agent Command Center layout to match the black and emerald design language
- add transcript timestamps, empty states, and reorganized panels per the specification
- update global styling for base background, typography, and scrollbars

## Testing
- npm install *(fails: 403 Forbidden from registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_68f8efe18f10832d8d05d5beb7e87e14